### PR TITLE
fix: handle nested generators correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,17 @@ npm i ghtml
 
 ### `html`
 
-The `html` function is used to tag template literals and escape their expressions. To bypass escaping an expression, prefix it with `!`.
+The `html` function is designed to tag template literals and automatically escape their expressions to prevent XSS attacks. To intentionally bypass escaping for a specific expression, prefix it with `!`.
 
 ### `htmlGenerator`
 
-The `htmlGenerator` function is the generator version of the `html` function. It allows for the generation of HTML fragments in an iterative manner, which can be particularly useful for large templates or when generating HTML on-the-fly.
+The `htmlGenerator` function acts as the generator version of the `html` function. It facilitates the creation of HTML fragments iteratively, making it ideal for parsing large templates or constructing HTML content dynamically.
 
-**Note:** It is important to note that, to be able to detect `htmlGenerator` usage in array methods such as `.map`, this function also checks if elements of an array expression are iterable as well and handles them accordingly. As a result, an expression like `${[[1, 2, 3], 4]}` (note how the first element is an array itself) will be rendered as `"1,2,34"` with `html`, but as `"1234"` with `htmlGenerator`.
+**Note:**
+
+A key difference of `htmlGenerator` is its ability to recognize and properly handle iterable elements within array expressions. This is to detect nested `htmlGenerator` usage, enabling scenarios such as ``[1,2,3].map(i => htmlGenerator`<li>${i}</li>`)``.
+
+As a side effect, an expression like `${[[1, 2, 3], 4]}` (where an element is an array itself) will not be rendered as `"1,2,34"`, which is the case with `html`, but as `"1234"`. This is the intended behavior most of the time anyway.
 
 ### `includeFile`
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ The `html` function is used to tag template literals and escape their expression
 
 The `htmlGenerator` function is the generator version of the `html` function. It allows for the generation of HTML fragments in an iterative manner, which can be particularly useful for large templates or when generating HTML on-the-fly.
 
-**Note:** It is important to note that, to be able to detect nested `htmlGenerator` usage, this function also checks if elements of an array expression are iterable as well and handles them accordingly. So an expression like `${[[1, 2, 3], 4]}` (note how the first element is an array itself) would be rendered as `"1,2,34"` with `html`, but as `"1234"` with `htmlGenerator`.
+**Note:** It is important to note that, to be able to detect `htmlGenerator` usage in array methods like `.map`, this function also checks if elements of an array expression are iterable as well and handles them accordingly.
+
+So an expression like `${[[1, 2, 3], 4]}` (note how the first element is an array itself) would be rendered as `"1,2,34"` with `html`, but as `"1234"` with `htmlGenerator`.
 
 ### `includeFile`
 
@@ -80,7 +82,7 @@ import { htmlGenerator as html } from "ghtml";
 import { Readable } from "node:stream";
 
 const htmlContent = html`<html>
-  <p>${"...your HTML content..."}</p>
+  <p>${"...HTML content..."}</p>
 </html>`;
 const readableStream = Readable.from(htmlContent);
 

--- a/README.md
+++ b/README.md
@@ -79,12 +79,11 @@ const htmlString = html`
 import { htmlGenerator as html } from "ghtml";
 import { Readable } from "node:stream";
 
-const htmlContent = html`<html>
-  <p>${"...HTML content..."}</p>
-</html>`;
-const readableStream = Readable.from(htmlContent);
-
 http.createServer((req, res) => {
+  const htmlContent = html`<html>
+    <p>${"...HTML content..."}</p>
+  </html>`;
+  const readableStream = Readable.from(htmlContent);
   res.writeHead(200, { "Content-Type": "text/html;charset=utf-8" });
   readableStream.pipe(res);
 });

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ The `html` function is used to tag template literals and escape their expression
 
 ### `htmlGenerator`
 
-The `htmlGenerator` function is the generator version of the `html` function. It allows for the generation of HTML fragments in a streaming manner, which can be particularly useful for large templates or when generating HTML on-the-fly.
+The `htmlGenerator` function is the generator version of the `html` function. It allows for the generation of HTML fragments in an iterative manner, which can be particularly useful for large templates or when generating HTML on-the-fly.
+
+**Note:** It is important to note that, to be able to detect nested `htmlGenerator` usage, this function also checks if elements of an array expression are iterable as well and handles them accordingly. So an expression like `${[[1, 2, 3], 4]}` (note how the first element is an array itself) would be rendered as `"1,2,34"` with `html`, but as `"1234"` with `htmlGenerator`.
 
 ### `includeFile`
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@ The `html` function is used to tag template literals and escape their expression
 
 The `htmlGenerator` function is the generator version of the `html` function. It allows for the generation of HTML fragments in an iterative manner, which can be particularly useful for large templates or when generating HTML on-the-fly.
 
-**Note:** It is important to note that, to be able to detect `htmlGenerator` usage in array methods like `.map`, this function also checks if elements of an array expression are iterable as well and handles them accordingly.
-
-So an expression like `${[[1, 2, 3], 4]}` (note how the first element is an array itself) would be rendered as `"1,2,34"` with `html`, but as `"1234"` with `htmlGenerator`.
+**Note:** It is important to note that, to be able to detect `htmlGenerator` usage in array methods such as `.map`, this function also checks if elements of an array expression are iterable as well and handles them accordingly. As a result, an expression like `${[[1, 2, 3], 4]}` (note how the first element is an array itself) will be rendered as `"1,2,34"` with `html`, but as `"1234"` with `htmlGenerator`.
 
 ### `includeFile`
 

--- a/README.md
+++ b/README.md
@@ -79,14 +79,16 @@ const htmlString = html`
 import { htmlGenerator as html } from "ghtml";
 import { Readable } from "node:stream";
 
-http.createServer((req, res) => {
-  const htmlContent = html`<html>
+http
+  .createServer((req, res) => {
+    const htmlContent = htmlGenerator`<html>
     <p>${"...HTML content..."}</p>
   </html>`;
-  const readableStream = Readable.from(htmlContent);
-  res.writeHead(200, { "Content-Type": "text/html;charset=utf-8" });
-  readableStream.pipe(res);
-});
+    const readableStream = Readable.from(htmlContent);
+    res.writeHead(200, { "Content-Type": "text/html;charset=utf-8" });
+    readableStream.pipe(res);
+  })
+  .listen(3000);
 ```
 
 ### `includeFile`

--- a/src/html.js
+++ b/src/html.js
@@ -63,8 +63,6 @@ const htmlGenerator = function* ({ raw: literals }, ...expressions) {
       expression = expressions[index];
     } else if (expressions[index] == null) {
       expression = "";
-    } else if (Array.isArray(expressions[index])) {
-      expression = expressions[index].join("");
     } else {
       if (typeof expressions[index][Symbol.iterator] === "function") {
         const isRaw =
@@ -79,14 +77,26 @@ const htmlGenerator = function* ({ raw: literals }, ...expressions) {
         }
 
         for (const value of expressions[index]) {
-          expression =
-            typeof value === "string"
-              ? value
-              : value == null
-                ? ""
-                : Array.isArray(value)
-                  ? value.join("")
-                  : `${value}`;
+          if (typeof value === "string") {
+            expression = value;
+          } else if (value == null) {
+            expression = "";
+          } else if (typeof value[Symbol.iterator] === "function") {
+            expression = "";
+
+            for (const innerValue of value) {
+              expression +=
+                typeof innerValue === "string"
+                  ? innerValue
+                  : innerValue == null
+                    ? ""
+                    : Array.isArray(innerValue)
+                      ? innerValue.join("")
+                      : `${innerValue}`;
+            }
+          } else {
+            expression = `${value}`;
+          }
 
           if (expression.length) {
             if (!isRaw) {

--- a/src/html.js
+++ b/src/html.js
@@ -85,14 +85,10 @@ const htmlGenerator = function* ({ raw: literals }, ...expressions) {
             expression = "";
 
             for (const innerValue of value) {
-              expression +=
-                typeof innerValue === "string"
-                  ? innerValue
-                  : innerValue == null
-                    ? ""
-                    : Array.isArray(innerValue)
-                      ? innerValue.join("")
-                      : `${innerValue}`;
+              if (innerValue != null) {
+                // At this level, we simply mirror Array.prototype.join
+                expression += innerValue;
+              }
             }
           } else {
             expression = `${value}`;

--- a/test/index.js
+++ b/test/index.js
@@ -163,23 +163,23 @@ test("htmlGenerator works with other generators", () => {
   assert.strictEqual(generator.next().done, true);
 });
 
-test("htmlGenerator works with other generators within an array", () => {
+test("htmlGenerator works with other generators within an array (raw)", () => {
   const generator = htmlGenerator`<div>!${[generatorExample()]}</div>`;
   assert.strictEqual(generator.next().value, "<div>");
   assert.strictEqual(
     generator.next().value,
-    "<p>This is a safe description.<script>alert('This is an unsafe description.')</script>12345255</p>",
+    "<p>This is a safe description.<script>alert('This is an unsafe description.')</script>1,2,3,4,5255</p>",
   );
   assert.strictEqual(generator.next().value, "</div>");
   assert.strictEqual(generator.next().done, true);
 });
 
-test("htmlGenerator works with other generators within an array", () => {
+test("htmlGenerator works with other generators within an array (escaped)", () => {
   const generator = htmlGenerator`<div>${[generatorExample()]}</div>`;
   assert.strictEqual(generator.next().value, "<div>");
   assert.strictEqual(
     generator.next().value,
-    "&lt;p&gt;This is a safe description.&lt;script&gt;alert(&apos;This is an unsafe description.&apos;)&lt;/script&gt;12345255&lt;/p&gt;",
+    "&lt;p&gt;This is a safe description.&lt;script&gt;alert(&apos;This is an unsafe description.&apos;)&lt;/script&gt;1,2,3,4,5255&lt;/p&gt;",
   );
   assert.strictEqual(generator.next().value, "</div>");
   assert.strictEqual(generator.next().done, true);

--- a/test/index.js
+++ b/test/index.js
@@ -147,6 +147,20 @@ test("htmlGenerator renders unsafe content", () => {
   );
 });
 
+test("htmlGenerator works with nested htmlGenerator calls", () => {
+  const generator = htmlGenerator`<ul>!${[1, 2, 3].map((index) => {
+    return htmlGenerator`<li>${index}</li>`;
+  })}</ul>`;
+  let accumulator = "";
+
+  for (const value of generator) {
+    accumulator += value;
+  }
+
+  assert.strictEqual(accumulator, "<ul><li>1</li><li>2</li><li>3</li></ul>");
+  assert.strictEqual(generator.next().done, true);
+});
+
 test("htmlGenerator works with other generators", () => {
   const generator = htmlGenerator`<div>!${generatorExample()}</div>`;
   assert.strictEqual(generator.next().value, "<div>");

--- a/test/index.js
+++ b/test/index.js
@@ -134,19 +134,17 @@ test("htmlGenerator renders safe content", () => {
 });
 
 test("htmlGenerator renders unsafe content", () => {
-  const generator = htmlGenerator`<p>${descriptionUnsafe}${descriptionUnsafe}${htmlGenerator`${array1}`}${null}${255}</p>`;
+  const generator = htmlGenerator`<p>${descriptionSafe}${descriptionUnsafe}${htmlGenerator`${array1}`}${null}${255}</p>`;
+  let accumulator = "";
+
+  for (const value of generator) {
+    accumulator += value;
+  }
+
   assert.strictEqual(
-    generator.next().value,
-    "<p>&lt;script&gt;alert(&apos;This is an unsafe description.&apos;)&lt;/script&gt;",
+    accumulator,
+    "<p>This is a safe description.&lt;script&gt;alert(&apos;This is an unsafe description.&apos;)&lt;/script&gt;12345255</p>",
   );
-  assert.strictEqual(
-    generator.next().value,
-    "&lt;script&gt;alert(&apos;This is an unsafe description.&apos;)&lt;/script&gt;",
-  );
-  assert.strictEqual(generator.next().value, "12345");
-  assert.strictEqual(generator.next().value, "255");
-  assert.strictEqual(generator.next().value, "</p>");
-  assert.strictEqual(generator.next().done, true);
 });
 
 test("htmlGenerator works with other generators", () => {
@@ -161,6 +159,28 @@ test("htmlGenerator works with other generators", () => {
   assert.strictEqual(generator.next().value, "12345");
   assert.strictEqual(generator.next().value, "255");
   assert.strictEqual(generator.next().value, "</p>");
+  assert.strictEqual(generator.next().value, "</div>");
+  assert.strictEqual(generator.next().done, true);
+});
+
+test("htmlGenerator works with other generators within an array", () => {
+  const generator = htmlGenerator`<div>!${[generatorExample()]}</div>`;
+  assert.strictEqual(generator.next().value, "<div>");
+  assert.strictEqual(
+    generator.next().value,
+    "<p>This is a safe description.<script>alert('This is an unsafe description.')</script>12345255</p>",
+  );
+  assert.strictEqual(generator.next().value, "</div>");
+  assert.strictEqual(generator.next().done, true);
+});
+
+test("htmlGenerator works with other generators within an array", () => {
+  const generator = htmlGenerator`<div>${[generatorExample()]}</div>`;
+  assert.strictEqual(generator.next().value, "<div>");
+  assert.strictEqual(
+    generator.next().value,
+    "&lt;p&gt;This is a safe description.&lt;script&gt;alert(&apos;This is an unsafe description.&apos;)&lt;/script&gt;12345255&lt;/p&gt;",
+  );
   assert.strictEqual(generator.next().value, "</div>");
   assert.strictEqual(generator.next().done, true);
 });

--- a/test/index.js
+++ b/test/index.js
@@ -147,7 +147,7 @@ test("htmlGenerator renders unsafe content", () => {
   );
 });
 
-test("htmlGenerator works with nested htmlGenerator calls", () => {
+test("htmlGenerator works with nested htmlGenerator calls in an array", () => {
   const generator = htmlGenerator`<ul>!${[1, 2, 3].map((index) => {
     return htmlGenerator`<li>${index}</li>`;
   })}</ul>`;


### PR DESCRIPTION
Every bugfix is a breaking change in some sense; here, what matters is that this PR corrects the behavior to what was intended when `htmlGenerator` was implemented