### PR TITLE
feat: escape `=`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ const username = '<img src="https://example.com/pwned.png">';
 const greeting = html`<h1>Hello, ${username}</h1>`;
 
 console.log(greeting);
-// Output: <h1>Hello, &#60;img src=&#34;https://example.com/pwned.png&#34;&#62;</h1>
+// Output: <h1>Hello, &#60;img src&#61;&#34;https://example.com/pwned.png&#34;&#62;</h1>
 ```
 
 To bypass escaping:

--- a/src/html.js
+++ b/src/html.js
@@ -1,4 +1,4 @@
-const escapeRegExp = /["&'<>`]/;
+const escapeRegExp = /["&'<=>`]/;
 
 const escapeFunction = (string) => {
   let escaped = "";
@@ -20,6 +20,10 @@ const escapeFunction = (string) => {
         continue;
       case 60: // <
         escaped += string.slice(start, end) + "&#60;";
+        start = end + 1;
+        continue;
+      case 61: // =
+        escaped += string.slice(start, end) + "&#61;";
         start = end + 1;
         continue;
       case 62: // >

--- a/test/index.js
+++ b/test/index.js
@@ -70,6 +70,14 @@ test("renders unsafe content /2", () => {
   );
 });
 
+test("renders unsafe content /3", () => {
+  // prettier-ignore
+  assert.strictEqual(
+    html`<img src="https://picsum.photos/200/300" alt=${"altText onload=alert(String.fromCharCode(112,119,110,101,100))"} />`,
+    `<img src="https://picsum.photos/200/300" alt=altText onload&#61;alert(String.fromCharCode(112,119,110,101,100)) />`,
+  );
+});
+
 test("renders arrays", () => {
   assert.strictEqual(
     html`<p>${[descriptionSafe, descriptionUnsafe]}</p>`,


### PR DESCRIPTION
I thought, [like Handlebars](https://handlebarsjs.com/guide/#html-escaping), escaping `` ` `` (on top of `'` and `"`) would help us prevent damage, in case an attacker manages to write JS on a page, by removing the ability to create template literals (as well as string literals), but none of them actually do anything useful in this case because `String.fromCharCode()` exists

Consider the following scenario where the user erroneously omits quotes from the `alt` attribute:

```js
const imgAlt = (request) => {
  return html`
    <img src="https://picsum.photos/200/300" alt=${request.query.alt} />
  `
```

If we click on the link `http://127.0.0.1:5000/?alt=altText%20onload=alert(String.fromCharCode(112,119,110,101,100))`, we'll get an alert that says `"pwned"`, so creating and using strings is indeed possible despite escaping all types of quotes

And since `` ` `` doesn't have a special meaning in HTML either, it seems like escaping it is not useful at all

But removing it could be breaking, and if we're going to release a new major, we better make sure to improve the design, which means having utility functions like `htmlAttr` instead of 1 function that tries to do everything

For now, I propose also escaping `=`, which prevents the creation of new attributes like `onload=` altogether, and for what it's worth, aligns the escaping behavior of ghtml with that of Handlebars

I didn't observe a significant drop in performance

_Users should stick to the common knowledge of always quoting their HTML attributes, as stated under the [Security section of our README](https://github.com/gurgunday/ghtml?tab=readme-ov-file#security)_